### PR TITLE
Backport fix for TestRPC compatibility with older versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,8 @@ class RpcBlockTracker extends AsyncEventEmitter {
     } catch (err) {
       
       // hotfix for https://github.com/ethereumjs/testrpc/issues/290
-      if (err.message.includes('index out of range')) {
+      if (err.message.includes('index out of range') ||
+          err.message.includes("Couldn't find block by reference")) {
         // set tracking block as current block
         await this._setCurrentBlock(trackingBlock)
         // setup poll for next block


### PR DESCRIPTION
This PR is a continuation of https://github.com/MetaMask/eth-block-tracker/pull/3, which is a hotfix to support testrpc despite returning an error instead of `null` when a block is not found. 

PR https://github.com/MetaMask/eth-block-tracker/pull/3 fixes it for testrpc's [master version](https://github.com/ethereumjs/testrpc/blob/de11ef0dc3c1b4609bb5f8a1cc223151b0d4c8b8/lib/database/leveluparrayadapter.js#L51),  but that version has a new "blockchain" system, so the hotfix doesn't work for any released version of testrpc.

Given that this hotfix was made to support older versions of testrpc being used by the ethereum developer community, I backported it so it works with any version after this commit: https://github.com/ethereumjs/testrpc/commit/e0707036300343a0fc8a258dff45f9b221fcbd80.

I haven't checked how many versions have been released since that commit was made, but at least all of 3.x.x versions will work.

