### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-block-tracker",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "This module walks the Ethereum blockchain, keeping track of the latest block. It uses a web3 provider as a data source and will continuously poll for the next block.",
   "main": "bundle.js",
   "scripts": {


### PR DESCRIPTION
For re-publishing with the build.js on master.  For some reason I wasn't able to reproduce, but hopefully there's just some config missing in the `package.json`.