### PR TITLE
WIP: Support tracking blocks via pubsub if supported by provider

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
   async _initSubscription() {
     this._provider.on('data', this._handleNewBlockNotification)
 
-    result = await pify(this._provider.sendAsync || this._provider.send)({
+    let result = await pify(this._provider.sendAsync || this._provider.send)({
       jsonrpc: '2.0',
       id: new Date().getTime(),
       method: 'eth_subscribe',

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
   constructor(opts = {}) {
     super()
     if (!opts.provider) throw new Error('RpcBlockTracker - no provider specified.')
+    this._provider = opts.provider
     this._query = new EthQuery(opts.provider)
     // config
     this._pollingInterval = opts.pollingInterval || 4e3 // 4 sec
@@ -22,6 +23,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
     // bind methods for cleaner syntax later
     this.emit = this.emit.bind(this)
     this._performSync = this._performSync.bind(this)
+    this._handleNewBlockNotification = this._handleNewBlockNotification.bind(this)
   }
 
   getTrackingBlock () {
@@ -53,14 +55,21 @@ class RpcBlockTracker extends AsyncEventEmitter {
       // or query for latest
       await this._setTrackingBlock(await this._fetchLatestBlock())
     }
-    this._performSync()
-    .catch((err) => {
-      if (err) console.error(err)
-    })
+    if (this._provider.on) {
+      await this._initSubscription()
+    } else {
+      this._performSync()
+        .catch((err) => {
+          if (err) console.error(err)
+        })
+    }
   }
 
-  stop () {
+  async stop () {
     this._isRunning = false
+    if (this._provider.on) {
+      await this._removeSubscription()
+    }
   }
 
   //
@@ -135,6 +144,50 @@ class RpcBlockTracker extends AsyncEventEmitter {
       }
 
     }
+  }
+
+  async _handleNewBlockNotification(err, notification) {
+    if (notification.id != this._subscriptionId)
+      return // this notification isn't for us
+
+    if (err) {
+      await pify(this.emit)('error', err)
+      await this._removeSubscription()
+    }
+
+    await this._setTrackingBlock(await this._fetchBlockByNumber(notification.result.number))
+  }
+
+  async _initSubscription() {
+    this._provider.on('data', this._handleNewBlockNotification)
+
+    result = await pify(this._provider.send)({
+      jsonrpc: '2.0',
+      id: new Date().getTime(),
+      method: 'eth_subscribe',
+      params: [
+        'newHeads'
+      ],
+    })
+
+    this._subscriptionId = result.result
+  }
+
+  async _removeSubscription() {
+    if (!this._subscriptionId) throw new Error("Not subscribed.")
+
+    this._provider.removeListener('data', this._handleNewBlockNotification)
+
+    await pify(this._provider.send)({
+      jsonrpc: '2.0',
+      id: new Date().getTime(),
+      method: 'eth_unsubscribe',
+      params: [
+        this._subscriptionId
+      ],
+    })
+
+    delete this._subscriptionId
   }
 
   _fetchLatestBlock () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
   async _initSubscription() {
     this._provider.on('data', this._handleNewBlockNotification)
 
-    result = await pify(this._provider.send)({
+    result = await pify(this._provider.sendAsync || this._provider.send)({
       jsonrpc: '2.0',
       id: new Date().getTime(),
       method: 'eth_subscribe',
@@ -178,7 +178,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
 
     this._provider.removeListener('data', this._handleNewBlockNotification)
 
-    await pify(this._provider.send)({
+    await pify(this._provider.sendAsync || this._provider.send)({
       jsonrpc: '2.0',
       id: new Date().getTime(),
       method: 'eth_unsubscribe',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run compile && browserify test/basic.js | node",
     "compile": "babel --presets es2015,stage-3 --plugins transform-runtime -d dist/ lib/",
-    "prepublishOnly": "npm run compile"
+    "prepare": "npm run compile"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Needs a test, but in order to do that properly it seems that I need to update `json-rpc-provider` to support pubsub.

Should fix #24.