### PR TITLE
Remove async eventemitter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
 // const EthQuery = require('ethjs-query')
 const EthQuery = require('eth-query')
-const AsyncEventEmitter = require('async-eventemitter')
+const EventEmitter = require('events')
 const pify = require('pify')
 const hexUtils = require('./hexUtils')
 const incrementHexNumber = hexUtils.incrementHexNumber
 
-class RpcBlockTracker extends AsyncEventEmitter {
+class RpcBlockTracker extends EventEmitter {
 
   constructor(opts = {}) {
     super()

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "async-eventemitter": "ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
     "eth-query": "^2.1.0",
     "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.3",


### PR DESCRIPTION
This module was casuing bugs that prevented my MetaMask from working.

It kept throwing the error documented here:
https://github.com/MetaMask/metamask-extension/issues/3262

Tracking down the nature of the problem was difficult, but it seemed that async-eventemitter was over-iterating its listener array.

Trying to even find that repo was difficult, no repo link on npm, hadn't been updated in 5 months, I'm not sure why we chose to rely on this module, but it smells bad to me.

On removing it, my MetaMask build works fine again. Please don't merge without answering this question:
Why did we want an async event emitter? What response needed to be executed in series?