### PR TITLE
Add undeclared dependency on babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "eth-json-rpc-infura": "^3.1.0",
     "eth-query": "^2.1.0",
     "pify": "^3.0.0"
@@ -23,6 +24,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
+    "babelify": "^8.0.0",
     "browserify": "^14.3.0",
     "ganache-core": "^2.1.0",
     "tape": "^4.9.0"


### PR DESCRIPTION
Also add undeclared devDependency on babelify to devDependencies
Allows usage with pnpm