### PR TITLE
Implement eth_subscribe based block tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "test": "npm run build && node test/index.js",
     "prepublish": "npm run build",
     "build": "mkdir -p ./dist && npm run bundle",
-    "bundle": "babel src -d dist/es5/ && npm run bundle-polling && npm run bundle-base",
+    "bundle": "babel src -d dist/es5/ && npm run bundle-polling && npm run bundle-subscribe && npm run bundle-base",
     "bundle-polling": "browserify -s PollingBlockTracker -e src/polling.js -t [ babelify --presets [ es2015 ] ] > dist/PollingBlockTracker.js",
+    "bundle-subscribe": "browserify -s SubscribeBlockTracker -e src/subscribe.js -t [ babelify --presets [ es2015 ] ] > dist/SubscribeBlockTracker.js",
     "bundle-base": "browserify -s BaseBlockTracker -e src/base.js -t [ babelify --presets [ es2015 ] ] > dist/BaseBlockTracker.js"
   },
   "author": "kumavis",

--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -1,0 +1,71 @@
+const EventEmitter = require('events')
+const BaseBlockTracker = require('./base')
+const createRandomId = require('json-rpc-random-id')()
+
+class SubscribeBlockTracker extends BaseBlockTracker {
+
+  constructor(opts = {}) {
+    // parse + validate args
+    if (!opts.provider) throw new Error('SubscribeBlockTracker - no provider specified.')
+    // BaseBlockTracker constructor
+    super(opts)
+    // config
+    this._provider = opts.provider
+  }
+
+  //
+  // public
+  //
+
+  async checkForLatestBlock() {
+    return await this.getLatestBlock()
+  }
+
+  //
+  // private
+  //
+
+  async _start() {
+    if (this._subscriptionId == null) {
+      try {
+        let blockNumber = await this._call('eth_blockNumber')
+        this._subscriptionId = await this._call('eth_subscribe', 'newHeads', {})
+        this._provider.on('data', this._handleSubData.bind(this))
+        this._newPotentialLatest(blockNumber)
+      } catch (e) {
+        this.emit('error', e)
+      }
+    }
+  }
+
+  async _end() {
+    if (this._subscriptionId != null) {
+      try {
+        await this._call('eth_unsubscribe', this._subscriptionId)
+        delete this._subscriptionId
+      } catch (e) {
+        this.emit('error', e)
+      }
+    }
+  }
+
+  _call(method) {
+    let params = Array.prototype.slice.call(arguments, 1)
+    return new Promise((resolve, reject) => {
+      this._provider.sendAsync({
+        id: createRandomId(), method, params, jsonrpc: "2.0"
+      }, (err, res) => {
+        if (err) reject(err)
+        else resolve(res.result)
+      })
+    })
+  }
+
+  _handleSubData(err, data) {
+    if (data.method === 'eth_subscription' && data.params.subscription === this._subscriptionId) {
+      this._newPotentialLatest(data.params.result.number)
+    }
+  }
+}
+
+module.exports = SubscribeBlockTracker

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,19 @@
 const test = require('tape')
 const SourcePollingBlockTracker = require('../src/polling')
 const DistPollingBlockTracker = require('../dist/PollingBlockTracker')
+const SourceSubscribeBlockTracker = require('../src/subscribe')
+const DistSubscribeBlockTracker = require('../dist/SubscribeBlockTracker')
 const SourceBaseBlockTracker = require('../src/base')
 const DistBaseBlockTracker = require('../dist/BaseBlockTracker')
 const runBaseTests = require('./base')
 const runPollingTests = require('./polling')
+const runSubscribeTests = require('./subscribe')
 
 runBaseTests(test, 'source - BaseBlockTracker', SourceBaseBlockTracker)
 runBaseTests(test, 'dist - BaseBlockTracker', DistBaseBlockTracker)
 
 runPollingTests(test, 'source - PollingBlockTracker', SourcePollingBlockTracker)
 runPollingTests(test, 'dist - PollingBlockTracker', DistPollingBlockTracker)
+
+runSubscribeTests(test, 'source - SubscribeBlockTracker', SourceSubscribeBlockTracker)
+runSubscribeTests(test, 'dist - SubscribeBlockTracker', DistSubscribeBlockTracker)

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -1,0 +1,60 @@
+const test = require('tape')
+const GanacheCore = require('ganache-core')
+const pify = require('pify')
+const SubscribeBlockTracker = require('../src/subscribe')
+const noop = () => {}
+
+module.exports = (test, testLabel, SubscribeBlockTracker) => {
+
+  test(`${testLabel} - latest`, async (t) => {
+    const provider = GanacheCore.provider()
+    const blockTracker = new SubscribeBlockTracker({
+      provider,
+    })
+
+    try {
+      t.equal(blockTracker.isRunning(), false, 'SubscribeBlockTracker should begin stopped')
+
+      const blocks = []
+      blockTracker.on('latest', (block) => blocks.push(block))
+      t.equal(blockTracker.isRunning(), true, 'SubscribeBlockTracker should start after listener is added')
+      t.equal(blocks.length, 0, 'no blocks so far')
+
+      await newLatestBlock(blockTracker)
+      t.equal(blocks.length, 1, 'saw 1st block')
+
+      let latestBlock = newLatestBlock(blockTracker)
+      await triggerNextBlock(provider)
+      await latestBlock
+      t.equal(blocks.length, 2, 'saw 2nd block')
+
+      await triggerNextBlock(provider)
+      await triggerNextBlock(provider)
+      let lastBlockPromise = newLatestBlock(blockTracker)
+      await triggerNextBlock(provider)
+      let lastBlock = await lastBlockPromise
+      t.equal(blocks.length, 5, 'saw all intermediate blocks')
+      t.equal(Number.parseInt(lastBlock, 16), 4, 'saw correct block, with number 4')
+
+      blockTracker.removeAllListeners()
+      t.equal(blockTracker.isRunning(), false, 'SubscribeBlockTracker stops after all listeners are removed')
+
+
+    } catch (err) {
+      t.ifError(err)
+    }
+
+    // cleanup
+    blockTracker.removeAllListeners()
+    t.end()
+  })
+
+}
+
+async function triggerNextBlock(provider) {
+  await pify((cb) => provider.sendAsync({ id: 1, method: 'evm_mine', jsonrpc: '2.0', params: [] }, cb))()
+}
+
+async function newLatestBlock(blockTracker) {
+  return await pify(blockTracker.once, { errorFirst: false }).call(blockTracker, 'latest')
+}


### PR DESCRIPTION
This pull request implements a second block tracker, based on `eth_subscribe`. For transports that support `eth_subscribe`, such as WebSockets and IPC, this should provide lower latency and lower overhead than the existing polling tracker.