### PR TITLE
Use correct notification ID when handling new data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,7 @@ class RpcBlockTracker extends EventEmitter {
   }
 
   async _handleNewBlockNotification(err, notification) {
-    if (notification.id != this._subscriptionId)
+    if (notification.params.subscription != this._subscriptionId)
       return // this notification isn't for us
 
     if (err) {
@@ -156,7 +156,7 @@ class RpcBlockTracker extends EventEmitter {
       await this._removeSubscription()
     }
 
-    await this._setTrackingBlock(await this._fetchBlockByNumber(notification.result.number))
+    await this._setTrackingBlock(await this._fetchBlockByNumber(notification.params.result.number))
   }
 
   async _initSubscription() {


### PR DESCRIPTION
This pull request updates the subscription callback code to grab the correct properties on the notification object.

Resolves #36 