### PR TITLE
Add jsonrpc to request of polling implementation

### DIFF
--- a/src/polling.js
+++ b/src/polling.js
@@ -66,7 +66,7 @@ class PollingBlockTracker extends BaseBlockTracker {
   }
 
   async _fetchLatestBlock () {
-    const req = { id: 1, method: 'eth_blockNumber', params: [] }
+    const req = { jsonrpc: "2.0", id: 1, method: 'eth_blockNumber', params: [] }
     if (this._setSkipCacheFlag) req.skipCache = true
     const res = await pify((cb) => this._provider.sendAsync(req, cb))()
     if (res.error) throw new Error(`PollingBlockTracker - encountered error fetching block:\n${res.error}`)


### PR DESCRIPTION
Request payload ```{"method":"eth_blockNumber","params":[],"id":1, "skipCache":true}``` yields: ```{"jsonrpc": "2.0", "id": null, "error": {"message": "Parse error", "code": -32700}}```

Request payload ```{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1, "skipCache":true}``` yields: ```{"jsonrpc": "2.0", "id": 1, "result": "0xa47c87"}```