### PR TITLE
Change hardcoded "id: 1" to random integer

### DIFF
--- a/src/polling.js
+++ b/src/polling.js
@@ -3,6 +3,8 @@ const BaseBlockTracker = require('./base')
 
 const sec = 1000
 
+const randomID = () => Math.floor(Math.random() * 100000000000)
+
 class PollingBlockTracker extends BaseBlockTracker {
 
   constructor (opts = {}) {
@@ -66,7 +68,7 @@ class PollingBlockTracker extends BaseBlockTracker {
   }
 
   async _fetchLatestBlock () {
-    const req = { jsonrpc: "2.0", id: 1, method: 'eth_blockNumber', params: [] }
+    const req = { jsonrpc: "2.0", id: randomID(), method: 'eth_blockNumber', params: [] }
     if (this._setSkipCacheFlag) req.skipCache = true
     const res = await pify((cb) => this._provider.sendAsync(req, cb))()
     if (res.error) throw new Error(`PollingBlockTracker - encountered error fetching block:\n${res.error}`)


### PR DESCRIPTION
This library has `id: 1` hardcoded when making RPC calls. Unfortunately, this causes some other RPC calls with the ID of 1 to be overriden. This is fixed by using a random integer for the RPC ID.