### PR TITLE
Use decompress@4.2.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,9 +2513,9 @@ decompress-unzip@^4.0.1:
     yauzl "^2.4.2"
 
 decompress@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
-  integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
+  integrity sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
   dependencies:
     decompress-tar "^4.0.0"
     decompress-tarbz2 "^4.0.0"


### PR DESCRIPTION
This change updates the `decompress` dependency to the latest published version, 4.2.1, to address a security advisory.

See https://www.npmjs.com/advisories/1217 for more information.

The `yarn audit` output:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Arbitrary File Write                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ decompress                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ganache-core                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ganache-core > web3 > web3-bzz > swarm-js > decompress       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1217                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
```