### PR TITLE
Use caniuse-lite@1.0.30001123

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,9 +2026,9 @@ camelcase@^3.0.0:
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000989:
-  version "1.0.30000989"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
-  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+  version "1.0.30001123"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001123.tgz#7b981d81382ab2c8fd062f3e6439215e8c503c22"
+  integrity sha512-03dJDoa4YC4332jq0rqwiM+Hw6tA5RJtrnZKvOQy7ASoIUv8CinkcmGhYpCvCjedvkBQrrKnkcELxrUSW/XwNQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR updates `caniuse-lite` to the latest version, addressing the following warnings shown during build:

```
$ yarn build && yarn test:unit && yarn test:lint:deps
$ yarn build:clean && yarn build:es5 && yarn build:bundle && yarn build:validate
$ rm -rf ./dist && mkdir -p ./dist
$ babel ./src -d dist/es5/
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
Successfully compiled 3 files with Babel.
$ yarn build:bundle:polling && yarn build:bundle:base && yarn build:bundle:subscribe
$ browserify -s PollingBlockTracker -e src/polling.js -g babelify > dist/PollingBlockTracker.js
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
$ browserify -s BaseBlockTracker -e src/base.js -g babelify > dist/BaseBlockTracker.js
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
$ browserify -s SubscribeBlockTracker -e src/subscribe.js -g babelify > dist/SubscribeBlockTracker.js
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
```