### PR TITLE
Remove sometimes-unsupported newHeads parameter

### DIFF
--- a/src/SubscribeBlockTracker.ts
+++ b/src/SubscribeBlockTracker.ts
@@ -43,7 +43,6 @@ export class SubscribeBlockTracker extends BaseBlockTracker {
         this._subscriptionId = (await this._call(
           'eth_subscribe',
           'newHeads',
-          {},
         )) as string;
         this._provider.on('data', this._handleSubData.bind(this));
         this._newPotentialLatest(blockNumber);


### PR DESCRIPTION
Thanks for all the work on this library! We use it in our [DApp](https://github.com/cardstack/cardstack/tree/main/packages/web-client), among other places.

We recently encountered some puzzling bugs that we eventually [tracked down](https://github.com/cardstack/cardstack/pull/2996) to a discrepancy in the way different RPC nodes support `eth_subscribe` for `newHeads`. We had switched to QuickNode and found that it rejected the `{}` parameter for `newHeads`:

```
quickNode = new WebSocket(QUICKNODE_WS_URL);
quickNode.onmessage = m => console.log(m.data);

quickNode.send('{"method":"eth_subscribe","params":["newHeads",{}],"id":1,"jsonrpc":"2.0"}')
> {"jsonrpc":"2.0","error":{"code":-32602,"message":"Couldn't parse parameters: newHeads","data":"\"Expected no parameters.\""},"id":1}

quickNode.send('{"method":"eth_subscribe","params":["newHeads"],"id":1,"jsonrpc":"2.0"}')
> {"jsonrpc":"2.0","result":"0xcfa1d5e8020c5a7f","id":1}
```

This caused the application to be unaware of new blocks having been mined, resulting in timeouts and stale data after blockchain operations.

Infura has no problem with the `{}`, unsurprising considering it’s the default RPC node for MetaMask:

```
infura = new WebSocket(INFURA_WS_URL);
infura.onmessage = m => console.log(m.data);

infura.send('{"method":"eth_subscribe","params":["newHeads",{}],"id":1,"jsonrpc":"2.0"}')
> {"jsonrpc":"2.0","id":1,"result":"0x41000f27fd80e1b9c0c9af0f373aacc8b8d60f64fe63"}

infura.send('{"method":"eth_subscribe","params":["newHeads"],"id":1,"jsonrpc":"2.0"}')
> {"jsonrpc":"2.0","id":1,"result":"0x41000f27fd804c3c9a677cb71ad90391856879328009"}
```

I can’t find explicit documentation of a standard on how this subscription should be initiated, but the [example call in EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#appendix-ii-examples) doesn’t include `{}`. [This `go-ethereum` comment](https://github.com/ethereum/go-ethereum/issues/21588#issuecomment-708992169) suggests it was never supported, though that seems not to be true in later releases; it is supported on `Geth/v1.10.15-omnibus-hotfix-f4decf48/linux-amd64/go1.17.6` at least, which is the version running on the Infura node I have access to.

Since all RPC nodes I’ve tested support `newHeads` with no `{}`, I suggest that it be removed so `eth-block-tracker` has the broadest support possible. Let me know your thoughts, thank you 😀