### PR TITLE
Drop Node 12, bump minimum Node to >= 14

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "~4.4.0"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
In order to add `@metamask/utils` as a dependency, we must upgrade the
minimum Node requirement from Node 12 to 14.