### PR TITLE
Align Provider type w/ other packages & re-expose

### DIFF
--- a/src/BaseBlockTracker.ts
+++ b/src/BaseBlockTracker.ts
@@ -1,18 +1,10 @@
 import SafeEventEmitter from '@metamask/safe-event-emitter';
-import { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine';
 
 const sec = 1000;
 
 const calculateSum = (accumulator: number, currentValue: number) =>
   accumulator + currentValue;
 const blockTrackerEvents: (string | symbol)[] = ['sync', 'latest'];
-
-export interface Provider extends SafeEventEmitter {
-  sendAsync: <T, U>(
-    req: JsonRpcRequest<T>,
-    cb: (err: Error, response: JsonRpcResponse<U>) => void,
-  ) => void;
-}
 
 interface BaseBlockTrackerArgs {
   blockResetDuration?: number;

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -1,8 +1,9 @@
 import getCreateRandomId from 'json-rpc-random-id';
 import pify from 'pify';
 import { JsonRpcRequest } from 'json-rpc-engine';
-import { BaseBlockTracker, Provider } from './BaseBlockTracker';
+import { BaseBlockTracker } from './BaseBlockTracker';
 import { projectLogger, createModuleLogger } from './logging-utils';
+import { Provider } from './types';
 
 const log = createModuleLogger(projectLogger, 'polling-block-tracker');
 const createRandomId = getCreateRandomId();

--- a/src/SubscribeBlockTracker.ts
+++ b/src/SubscribeBlockTracker.ts
@@ -1,6 +1,7 @@
 import getCreateRandomId from 'json-rpc-random-id';
 import { JsonRpcNotification, JsonRpcSuccess } from 'json-rpc-engine';
-import { BaseBlockTracker, Provider } from './BaseBlockTracker';
+import { BaseBlockTracker } from './BaseBlockTracker';
+import { Provider } from './types';
 
 const createRandomId = getCreateRandomId();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './PollingBlockTracker';
 export * from './SubscribeBlockTracker';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+import SafeEventEmitter from '@metamask/safe-event-emitter';
+import { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine';
+
+// This type should be compatible with the one defined in
+// `eth-json-rpc-middleware`.
+export interface Provider extends SafeEventEmitter {
+  sendAsync: <T, U>(
+    req: JsonRpcRequest<T>,
+    cb: (err: unknown, response: JsonRpcResponse<U>) => void,
+  ) => void;
+}

--- a/tests/withBlockTracker.ts
+++ b/tests/withBlockTracker.ts
@@ -1,15 +1,13 @@
 import util from 'util';
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine';
-import { Provider } from '../src/BaseBlockTracker';
-import {
-  SubscribeBlockTracker,
-  SubscribeBlockTrackerOptions,
-} from '../src/SubscribeBlockTracker';
 import {
   PollingBlockTracker,
   PollingBlockTrackerOptions,
-} from '../src/PollingBlockTracker';
+  Provider,
+  SubscribeBlockTracker,
+  SubscribeBlockTrackerOptions,
+} from '../src';
 
 interface WithPollingBlockTrackerOptions {
   provider?: FakeProviderOptions;


### PR DESCRIPTION
The Provider type which is used internally by this package is not compatible with the SafeEventEmitterProvider type used by `eth-json-rpc-middleware`. This means that whenever using this package with `eth-json-rpc-middleware` we have to resort to the following hackery:

```
import { PollingBlockTracker, Provider } from 'eth-block-tracker';
import { JsonRpcEngine } from 'json-rpc-engine';
import { providerFromEngine } from '../src';

const engine = new JsonRpcEngine();
const provider = providerFromEngine(engine);

const blockTracker = new PollingBlockTracker({
  // Notice the typecasting here
  provider: provider as Provider,
});
```

SafeEventEmitterProvider is the more accurate type here in this case, because it correctly types the `error` argument for the callback that `sendAsync` calls as `unknown` rather than `Error`, so we follow suit here.

Additionally, this package used to expose the Provider type and that was changed in 6.0.0 without being documented, probably because it was located in the same file as BaseBlockTracker. So here we move the type to a more obvious place and re-expose it.

---

Fixes #114.