### PR TITLE
Fix getLatestBlock to stop block tracker afterward

### DIFF
--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -85,10 +85,11 @@ export class PollingBlockTracker extends BaseBlockTracker {
             err.stack ?? err
           }`,
         );
+        console.error(newErr);
         try {
           this.emit('error', newErr);
         } catch (emitErr) {
-          console.error(newErr);
+          // No "error" listener is attached
         }
         const promise = timeout(this._retryTimeout, !this._keepEventLoopActive);
         this.emit('_waitingForNextIteration');


### PR DESCRIPTION
`getLatestBlock` returns a promise that resolves to the latest block number. How it obtains the latest block number depends on whether the block tracker is already running and which type of block tracker is being accessed. If the block tracker is already started, then `getLatestBlock` will simply wait until the next iteration of the loop (in the case of PollingBlockTracker) or the next block to arrive (in the case of SubscribeBlockTracker). Otherwise, it needs to start the block tracker automatically, wait, and then stop it automatically after it has obtained the block number.

However, a problem lies with the second possibility. If there is a problem retrieving the block number — if the request fails in the case of PollingBlockTracker or if an error is thrown while waiting for the next block in the case of SubscribeBlockTracker — then the block tracker will never get stopped. This occurs even when the network is switched.

How do we fix this? Part of the issue is that the `latest` event is "magic". The block tracker does not run automatically but runs only when it's needed. As soon as anything listens to `latest`, the block tracker will start; and if nothing is listening to `latest`, the block tracker will stop. This applies even if the thing that's listening to `latest` is the block tracker itself.

So the main thing that we change about `getLatestBlock` is to create an internal event that is not magic, and we handle starting and stopping ourselves. The other thing is that we watch for errors to occur. Putting that together, we can ensure that whether or not there is an error, we stop the block tracker if it needs to be stopped once we're done.

Fixes #163.