### PR TITLE
Prevent multiple simultaneous polling loops

### DIFF
--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -43,6 +43,8 @@ export class PollingBlockTracker
 
   private _blockResetTimeout?: ReturnType<typeof setTimeout>;
 
+  private _pollingTimeout?: ReturnType<typeof setTimeout>;
+
   private readonly _provider: SafeEventEmitterProvider;
 
   private readonly _pollingInterval: number;
@@ -87,7 +89,7 @@ export class PollingBlockTracker
 
   async destroy() {
     this._cancelBlockResetTimeout();
-    await this._maybeEnd();
+    this._maybeEnd();
     super.removeAllListeners();
   }
 
@@ -154,24 +156,26 @@ export class PollingBlockTracker
     this._maybeEnd();
   }
 
-  private async _maybeStart(): Promise<void> {
+  private _maybeStart() {
     if (this._isRunning) {
       return;
     }
+
     this._isRunning = true;
     // cancel setting latest block to stale
     this._cancelBlockResetTimeout();
-    await this._start();
+    this._start();
     this.emit('_started');
   }
 
-  private async _maybeEnd(): Promise<void> {
+  private _maybeEnd() {
     if (!this._isRunning) {
       return;
     }
+
     this._isRunning = false;
     this._setupBlockResetTimeout();
-    await this._end();
+    this._end();
     this.emit('_ended');
   }
 
@@ -240,40 +244,12 @@ export class PollingBlockTracker
     return await this.getLatestBlock();
   }
 
-  private async _start(): Promise<void> {
-    this._synchronize();
+  private _start() {
+    this._updateAndQueue();
   }
 
-  private async _end(): Promise<void> {
-    // No-op
-  }
-
-  private async _synchronize(): Promise<void> {
-    while (this._isRunning) {
-      try {
-        await this._updateLatestBlock();
-        const promise = timeout(
-          this._pollingInterval,
-          !this._keepEventLoopActive,
-        );
-        this.emit('_waitingForNextIteration');
-        await promise;
-      } catch (err: any) {
-        const newErr = new Error(
-          `PollingBlockTracker - encountered an error while attempting to update latest block:\n${
-            err.stack ?? err
-          }`,
-        );
-        try {
-          this.emit('error', newErr);
-        } catch (emitErr) {
-          console.error(newErr);
-        }
-        const promise = timeout(this._retryTimeout, !this._keepEventLoopActive);
-        this.emit('_waitingForNextIteration');
-        await promise;
-      }
-    }
+  private _end() {
+    this._clearPollingTimeout();
   }
 
   private async _updateLatestBlock(): Promise<void> {
@@ -303,25 +279,53 @@ export class PollingBlockTracker
     }
     return res.result;
   }
-}
 
-/**
- * Waits for the specified amount of time.
- *
- * @param duration - The amount of time in milliseconds.
- * @param unref - Assuming this function is run in a Node context, governs
- * whether Node should wait before the `setTimeout` has completed before ending
- * the process (true for no, false for yes). Defaults to false.
- * @returns A promise that can be used to wait.
- */
-async function timeout(duration: number, unref: boolean) {
-  return new Promise((resolve) => {
-    const timeoutRef = setTimeout(resolve, duration);
-    // don't keep process open
-    if (timeoutRef.unref && unref) {
+  private async _updateAndQueue() {
+    let interval = this._pollingInterval;
+
+    try {
+      await this._updateLatestBlock();
+    } catch (err: any) {
+      const newErr = new Error(
+        `PollingBlockTracker - encountered an error while attempting to update latest block:\n${
+          err.stack ?? err
+        }`,
+      );
+
+      try {
+        this.emit('error', newErr);
+      } catch (emitErr) {
+        console.error(newErr);
+      }
+
+      interval = this._retryTimeout;
+    }
+
+    if (!this._isRunning) {
+      return;
+    }
+
+    this._clearPollingTimeout();
+
+    const timeoutRef = setTimeout(() => {
+      this._updateAndQueue();
+    }, interval);
+
+    if (timeoutRef.unref && !this._keepEventLoopActive) {
       timeoutRef.unref();
     }
-  });
+
+    this._pollingTimeout = timeoutRef;
+
+    this.emit('_waitingForNextIteration');
+  }
+
+  _clearPollingTimeout() {
+    if (this._pollingTimeout) {
+      clearTimeout(this._pollingTimeout);
+      this._pollingTimeout = undefined;
+    }
+  }
 }
 
 /**

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -245,6 +245,8 @@ export class PollingBlockTracker
   }
 
   private _start() {
+    // Intentionally not awaited as this starts the polling via a timeout chain.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this._updateAndQueue();
   }
 
@@ -280,6 +282,10 @@ export class PollingBlockTracker
     return res.result;
   }
 
+  /**
+   * The core polling function that runs after each interval.
+   * Updates the latest block and then queues the next update.
+   */
   private async _updateAndQueue() {
     let interval = this._pollingInterval;
 
@@ -308,6 +314,8 @@ export class PollingBlockTracker
     this._clearPollingTimeout();
 
     const timeoutRef = setTimeout(() => {
+      // Intentionally not awaited as this just continues the polling loop.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this._updateAndQueue();
     }, interval);
 

--- a/tests/recordCallsToSetTimeout.ts
+++ b/tests/recordCallsToSetTimeout.ts
@@ -99,6 +99,10 @@ class SetTimeoutRecorder {
     });
   }
 
+  findCallsMatchingDuration(duration: number): SetTimeoutCall[] {
+    return this.calls.filter((call) => call.duration === duration);
+  }
+
   /**
    * Registers a callback that will be called when `setTimeout` is called and
    * the expected number of `setTimeout` calls (as specified via


### PR DESCRIPTION
**Problem**

The central mechanism of the `PollingBlockTracker` is the `synchronize` method which provides a loop to fetch the block number then wait for a given interval, all until the block tracker is no longer running meaning it no longer has any event listeners.

If all listeners are removed while the `synchronize` loop is waiting for the timeout, once the timeout finishes the loop will exit since `isRunning` will now be `false`.

If all listeners are removed but then some are added again, all while waiting for a timeout, this allows a new synchronise loop to be created since `isRunning` was `false` meaning `_maybeStart` > `_start` > `_synchronize`. Once the original timeout finishes however, it continues as normal since `isRunning` is `true` again meaning we now have two synchronize loops occurring simultaneously with different interval alignment meaning we ultimately poll more often than the desired polling interval. This problem can stack and create many simultaneous loops thereby greatly increasing the actual polling interval.

**Test Steps**

1. Close all extension tabs and popups.
2. Open the extension popup.
3. Close the extension popup.
4. Repeat steps 2 and 3 multiple times to increase the impact.
5. Open the extension and expand view into a new tab (to keep the incoming transaction listener present).
6. Note in the console that the block tracker makes requests as fast as every second.

**Solution**

There are multiple possible solutions but for the sake of the simplest final code, this PR replaces the `synchronize` loop with a `setTimeout` chain.

This allows duplicate "loops" to be easily avoided since we can simply clear any pending timeouts before creating a new one, plus do the same when all listeners are removed and the `_end` method is ultimately called.

In addition, we can simplify the `_maybeStart`, `_maybeEnd`, `_start`, and `_end` methods by removing the `async` keyword since no asynchronous logic is required. This introduces additional clarity in code path since we are invoking these methods from synchronous event listeners meaning it is ideal that we only require synchronous methods.

Note that `updateAndQueue` is an `async` method but we don't need to `await` this since we want to emit the `_started` event before the first iteration has been completed, and it includes its own error handling.