### PR TITLE
fix: internal listeners infinite retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Avoid risk of infinte retry loops when fetching new blocks ([#284](https://github.com/MetaMask/eth-block-tracker/pull/284))
+- Avoid risk of infinite retry loops when fetching new blocks ([#284](https://github.com/MetaMask/eth-block-tracker/pull/284))
 
 ## [11.0.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Avoid risk of infinite retry loops when fetching new blocks ([#284](https://github.com/MetaMask/eth-block-tracker/pull/284))
+  - When the provider returns an error and `PollingBlockTracker` or `SubscribeBlockTracker` is destroyed, the promise returned by the `getLatestBlock` method will be rejected.
 
 ## [11.0.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid risk of infinte retry loops when fetching new blocks ([#284](https://github.com/MetaMask/eth-block-tracker/pull/284))
 
 ## [11.0.2]
 ### Fixed

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -213,7 +213,7 @@ describe('PollingBlockTracker', () => {
     });
 
     it('should not retry failed requests after the block tracker is stopped', async () => {
-      recordCallsToSetTimeout({ numAutomaticCalls: 1 });
+      recordCallsToSetTimeout({ numAutomaticCalls: 2 });
 
       await withPollingBlockTracker(
         {

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -185,7 +185,7 @@ describe('PollingBlockTracker', () => {
       );
     });
 
-    it('should not retry failed requests after the block tracker is stopped', async () => {
+    it('should return a promise that rejects if the request for the block number fails and the block tracker is then stopped', async () => {
       recordCallsToSetTimeout({ numAutomaticCalls: 1 });
 
       await withPollingBlockTracker(

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -212,17 +212,6 @@ describe('PollingBlockTracker', () => {
       );
     });
 
-    it('should return the same promise if called multiple times', async () => {
-      await withPollingBlockTracker(async ({ blockTracker }) => {
-        const promiseToGetLatestBlock1 = blockTracker.getLatestBlock();
-        const promiseToGetLatestBlock2 = blockTracker.getLatestBlock();
-
-        expect(promiseToGetLatestBlock1).toStrictEqual(
-          promiseToGetLatestBlock2,
-        );
-      });
-    });
-
     it('should return a promise that resolves when a new block is available', async () => {
       recordCallsToSetTimeout();
 

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -205,7 +205,7 @@ describe('PollingBlockTracker', () => {
           expect(blockTracker.isRunning()).toBe(true);
           await blockTracker.destroy();
           await expect(latestBlockPromise).rejects.toThrow(
-            'Block tracker ended before latest block was available',
+            'Block tracker destroeyd',
           );
           expect(blockTracker.isRunning()).toBe(false);
         },

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -212,6 +212,62 @@ describe('PollingBlockTracker', () => {
       );
     });
 
+    it('should return the same promise if called multiple times', async () => {
+      await withPollingBlockTracker(async ({ blockTracker }) => {
+        const promiseToGetLatestBlock1 = blockTracker.getLatestBlock();
+        const promiseToGetLatestBlock2 = blockTracker.getLatestBlock();
+
+        expect(promiseToGetLatestBlock1).toStrictEqual(
+          promiseToGetLatestBlock2,
+        );
+      });
+    });
+
+    it('should return a promise that resolves when a new block is available', async () => {
+      recordCallsToSetTimeout();
+
+      await withPollingBlockTracker(
+        {
+          provider: {
+            stubs: [
+              {
+                methodName: 'eth_blockNumber',
+                result: '0x1',
+              },
+            ],
+          },
+        },
+        async ({ blockTracker }) => {
+          expect(await blockTracker.getLatestBlock()).toBe('0x1');
+        },
+      );
+    });
+
+    it('should resolve all returned promises when a new block is available', async () => {
+      recordCallsToSetTimeout();
+
+      await withPollingBlockTracker(
+        {
+          provider: {
+            stubs: [
+              {
+                methodName: 'eth_blockNumber',
+                result: '0x1',
+              },
+            ],
+          },
+        },
+        async ({ blockTracker }) => {
+          const promises = [
+            blockTracker.getLatestBlock(),
+            blockTracker.getLatestBlock(),
+          ];
+
+          expect(await Promise.all(promises)).toStrictEqual(['0x1', '0x1']);
+        },
+      );
+    });
+
     it('request the latest block number with `skipCache: true` if the block tracker was initialized with `setSkipCacheFlag: true`', async () => {
       recordCallsToSetTimeout();
 
@@ -600,6 +656,33 @@ describe('PollingBlockTracker', () => {
         await blockTracker.checkForLatestBlock();
         expect(blockTracker.isRunning()).toBe(false);
       });
+    });
+
+    it('should return the same promise if called multiple times', async () => {
+      await withPollingBlockTracker(
+        {
+          provider: {
+            stubs: [
+              {
+                methodName: 'eth_blockNumber',
+                result: '0x0',
+              },
+              {
+                methodName: 'eth_blockNumber',
+                result: '0x1',
+              },
+            ],
+          },
+        },
+        async ({ blockTracker }) => {
+          const promiseToCheckLatestBlock1 = blockTracker.checkForLatestBlock();
+          const promiseToCheckLatestBlock2 = blockTracker.checkForLatestBlock();
+
+          expect(promiseToCheckLatestBlock1).toStrictEqual(
+            promiseToCheckLatestBlock2,
+          );
+        },
+      );
     });
 
     it('should fetch the latest block number', async () => {

--- a/src/PollingBlockTracker.test.ts
+++ b/src/PollingBlockTracker.test.ts
@@ -205,7 +205,7 @@ describe('PollingBlockTracker', () => {
           expect(blockTracker.isRunning()).toBe(true);
           await blockTracker.destroy();
           await expect(latestBlockPromise).rejects.toThrow(
-            'Block tracker destroeyd',
+            'Block tracker destroyed',
           );
           expect(blockTracker.isRunning()).toBe(false);
         },

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -189,14 +189,17 @@ export class PollingBlockTracker
   }
 
   private _getBlockTrackerEventCount(): number {
-    return blockTrackerEvents
-      .map((eventName) => this.listeners(eventName))
-      .flat()
-      .filter((listener) =>
-        this.#onLatestBlockInternalListeners.every(
-          (internalListener) => !Object.is(internalListener, listener),
-        ),
-      ).length;
+    return (
+      blockTrackerEvents
+        .map((eventName) => this.listeners(eventName))
+        .flat()
+        // internal listeners are not included in the count
+        .filter((listener) =>
+          this.#onLatestBlockInternalListeners.every(
+            (internalListener) => !Object.is(internalListener, listener),
+          ),
+        ).length
+    );
   }
 
   private _shouldUseNewBlock(newBlock: string) {

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -126,7 +126,8 @@ export class PollingBlockTracker
     // wait for a new latest block
     const onLatestBlock = (value: string) => {
       this.#removeInternalListener(onLatestBlock);
-      this.#resolvePendingLatestBlock(value);
+      resolve(value);
+      this.#pendingLatestBlock = undefined;
     };
     this.#addInternalListener(onLatestBlock);
     this.once('latest', onLatestBlock);
@@ -371,11 +372,6 @@ export class PollingBlockTracker
       this.#internalEventListeners.indexOf(listener),
       1,
     );
-  }
-
-  #resolvePendingLatestBlock(value: string) {
-    this.#pendingLatestBlock?.resolve(value);
-    this.#pendingLatestBlock = undefined;
   }
 
   #rejectPendingLatestBlock(error: unknown) {

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -52,7 +52,7 @@ export class PollingBlockTracker
 
   private readonly _setSkipCacheFlag: boolean;
 
-  readonly #onLatestBlockInternalListeners: ((
+  readonly #internalEventListeners: ((
     value: string | PromiseLike<string>,
   ) => void)[] = [];
 
@@ -110,13 +110,13 @@ export class PollingBlockTracker
     // wait for a new latest block
     const latestBlock: string = await new Promise((resolve) => {
       const listener = (value: string | PromiseLike<string>) => {
-        this.#onLatestBlockInternalListeners.splice(
-          this.#onLatestBlockInternalListeners.indexOf(listener),
+        this.#internalEventListeners.splice(
+          this.#internalEventListeners.indexOf(listener),
           1,
         );
         resolve(value);
       };
-      this.#onLatestBlockInternalListeners.push(listener);
+      this.#internalEventListeners.push(listener);
       this.once('latest', listener);
     });
     // return newly set current block
@@ -195,7 +195,7 @@ export class PollingBlockTracker
         .flat()
         // internal listeners are not included in the count
         .filter((listener) =>
-          this.#onLatestBlockInternalListeners.every(
+          this.#internalEventListeners.every(
             (internalListener) => !Object.is(internalListener, listener),
           ),
         ).length

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -195,9 +195,7 @@ export class PollingBlockTracker
         .flat()
         // internal listeners are not included in the count
         .filter((listener) =>
-          this.#internalEventListeners.every(
-            (internalListener) => !Object.is(internalListener, listener),
-          ),
+          this.#internalEventListeners.includes(listener),
         ).length
     );
   }

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -195,7 +195,9 @@ export class PollingBlockTracker
         .flat()
         // internal listeners are not included in the count
         .filter((listener) =>
-          this.#internalEventListeners.includes(listener),
+          this.#internalEventListeners.every(
+            (internalListener) => !Object.is(internalListener, listener),
+          ),
         ).length
     );
   }

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -61,7 +61,7 @@ export class PollingBlockTracker
 
   readonly #internalEventListeners: InternalListener[] = [];
 
-  #pendingLatestBlock?: DeferredPromise<string>;
+  #pendingLatestBlock?: Omit<DeferredPromise<string>, 'resolve'>;
 
   constructor(opts: PollingBlockTrackerOptions = {}) {
     // parse + validate args
@@ -121,7 +121,7 @@ export class PollingBlockTracker
     const { promise, resolve, reject } = createDeferredPromise<string>({
       suppressUnhandledRejection: true,
     });
-    this.#pendingLatestBlock = { promise, resolve, reject };
+    this.#pendingLatestBlock = { reject, promise };
 
     // wait for a new latest block
     const onLatestBlock = (value: string) => {

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -125,6 +125,7 @@ export class PollingBlockTracker
       let onLatestBlockUnavailable: InternalListener;
       const onLatestBlockAvailable = (value: string | PromiseLike<string>) => {
         this.#removeInternalListener(onLatestBlockAvailable);
+        this.#removeInternalListener(onLatestBlockUnavailable);
         this.removeListener('error', onLatestBlockUnavailable);
         resolve(value);
       };

--- a/src/PollingBlockTracker.ts
+++ b/src/PollingBlockTracker.ts
@@ -130,7 +130,7 @@ export class PollingBlockTracker
     const onLatestBlock = (value: string) => {
       this.#removeInternalListener(onLatestBlock);
       resolve(value);
-      delete this.#pendingLatestBlock;
+      this.#pendingLatestBlock = undefined;
     };
     this.#addInternalListener(onLatestBlock);
     this.once('latest', onLatestBlock);

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -142,6 +142,21 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
+      it('should return the same promise if called multiple times', async () => {
+        recordCallsToSetTimeout();
+
+        await withSubscribeBlockTracker(async ({ blockTracker }) => {
+          const promiseToGetLatestBlock1 =
+            blockTracker[methodToGetLatestBlock]();
+          const promiseToGetLatestBlock2 =
+            blockTracker[methodToGetLatestBlock]();
+
+          expect(promiseToGetLatestBlock1).toStrictEqual(
+            promiseToGetLatestBlock2,
+          );
+        });
+      });
+
       it('should stop the block tracker automatically after its promise is fulfilled', async () => {
         recordCallsToSetTimeout();
 

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -142,21 +142,6 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
-      it('should return the same promise if called multiple times', async () => {
-        recordCallsToSetTimeout();
-
-        await withSubscribeBlockTracker(async ({ blockTracker }) => {
-          const promiseToGetLatestBlock1 =
-            blockTracker[methodToGetLatestBlock]();
-          const promiseToGetLatestBlock2 =
-            blockTracker[methodToGetLatestBlock]();
-
-          expect(promiseToGetLatestBlock1).toStrictEqual(
-            promiseToGetLatestBlock2,
-          );
-        });
-      });
-
       it('should stop the block tracker automatically after its promise is fulfilled', async () => {
         recordCallsToSetTimeout();
 

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -278,7 +278,7 @@ describe('SubscribeBlockTracker', () => {
       });
 
       METHODS_TO_ADD_LISTENER.forEach((methodToAddListener) => {
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request for the latest block number, the provider throws an Error`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request for the latest block number, the provider throws an Error`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
           const thrownError = new Error('boom');
 
@@ -296,21 +296,19 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError).toBe(thrownError);
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toThrow(thrownError);
+              expect(listener).toHaveBeenCalledWith(thrownError);
             },
           );
         });
 
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request for the latest block number, the provider throws a string`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request for the latest block number, the provider throws a string`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
           const thrownString = 'boom';
 
@@ -328,21 +326,19 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError).toBe(thrownString);
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toBe(thrownString);
+              expect(listener).toHaveBeenCalledWith(thrownString);
             },
           );
         });
 
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request for the latest block number, the provider rejects with an error`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request for the latest block number, the provider rejects with an error`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
 
           await withSubscribeBlockTracker(
@@ -357,21 +353,19 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError.message).toBe('boom');
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toThrow('boom');
+              expect(listener).toHaveBeenCalledWith(new Error('boom'));
             },
           );
         });
 
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request to subscribe, the provider throws an Error`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request to subscribe, the provider throws an Error`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
           const thrownError = new Error('boom');
 
@@ -389,21 +383,19 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError).toBe(thrownError);
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toThrow(thrownError);
+              expect(listener).toHaveBeenCalledWith(thrownError);
             },
           );
         });
 
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request to subscribe, the provider throws a string`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request to subscribe, the provider throws a string`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
           const thrownString = 'boom';
 
@@ -421,21 +413,19 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError).toBe(thrownString);
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toBe(thrownString);
+              expect(listener).toHaveBeenCalledWith(thrownString);
             },
           );
         });
 
-        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should never resolve if, while making the request to subscribe, the provider rejects with an error`, async () => {
+        it(`should emit the "error" event (added via \`${methodToAddListener}\`) and should reject if, while making the request to subscribe, the provider rejects with an error`, async () => {
           recordCallsToSetTimeout({ numAutomaticCalls: 1 });
 
           await withSubscribeBlockTracker(
@@ -450,16 +440,14 @@ describe('SubscribeBlockTracker', () => {
               },
             },
             async ({ blockTracker }) => {
-              const promiseForCaughtError = new Promise<any>((resolve) => {
-                blockTracker[methodToAddListener]('error', resolve);
-              });
+              const listener = jest.fn();
+              blockTracker[methodToAddListener]('error', listener);
 
               const promiseForLatestBlock =
                 blockTracker[methodToGetLatestBlock]();
 
-              const caughtError = await promiseForCaughtError;
-              expect(caughtError.message).toBe('boom');
-              await expect(promiseForLatestBlock).toNeverResolve();
+              await expect(promiseForLatestBlock).rejects.toThrow('boom');
+              expect(listener).toHaveBeenCalledWith(new Error('boom'));
             },
           );
         });

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -151,33 +151,6 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
-      it('should not retry failed requests after the block tracker is stopped', async () => {
-        recordCallsToSetTimeout({ numAutomaticCalls: 1 });
-
-        await withSubscribeBlockTracker(
-          {
-            provider: {
-              stubs: [
-                {
-                  methodName: 'eth_blockNumber',
-                  error: 'boom',
-                },
-              ],
-            },
-          },
-          async ({ blockTracker }) => {
-            const latestBlockPromise = blockTracker[methodToGetLatestBlock]();
-
-            expect(blockTracker.isRunning()).toBe(true);
-            await blockTracker.destroy();
-            await expect(latestBlockPromise).rejects.toThrow(
-              'Block tracker destroyed',
-            );
-            expect(blockTracker.isRunning()).toBe(false);
-          },
-        );
-      });
-
       it('should fetch the latest block number', async () => {
         recordCallsToSetTimeout();
 

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -151,6 +151,33 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
+      it('should not retry failed requests after the block tracker is stopped', async () => {
+        recordCallsToSetTimeout({ numAutomaticCalls: 1 });
+
+        await withSubscribeBlockTracker(
+          {
+            provider: {
+              stubs: [
+                {
+                  methodName: 'eth_blockNumber',
+                  error: 'boom',
+                },
+              ],
+            },
+          },
+          async ({ blockTracker }) => {
+            const latestBlockPromise = blockTracker[methodToGetLatestBlock]();
+
+            expect(blockTracker.isRunning()).toBe(true);
+            await blockTracker.destroy();
+            await expect(latestBlockPromise).rejects.toThrow(
+              'Block tracker ended before latest block was available',
+            );
+            expect(blockTracker.isRunning()).toBe(false);
+          },
+        );
+      });
+
       it('should fetch the latest block number', async () => {
         recordCallsToSetTimeout();
 

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -151,6 +151,31 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
+      it('should resolve all returned promises when a new block is available', async () => {
+        recordCallsToSetTimeout();
+
+        await withSubscribeBlockTracker(
+          {
+            provider: {
+              stubs: [
+                {
+                  methodName: 'eth_blockNumber',
+                  result: '0x1',
+                },
+              ],
+            },
+          },
+          async ({ blockTracker }) => {
+            const promises = [
+              blockTracker.getLatestBlock(),
+              blockTracker.getLatestBlock(),
+            ];
+
+            expect(await Promise.all(promises)).toStrictEqual(['0x1', '0x1']);
+          },
+        );
+      });
+
       it('should reject the returned promise if the block tracker is destroyed in the meantime', async () => {
         await withSubscribeBlockTracker(async ({ blockTracker }) => {
           const promiseToGetLatestBlock =

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -171,7 +171,7 @@ describe('SubscribeBlockTracker', () => {
             expect(blockTracker.isRunning()).toBe(true);
             await blockTracker.destroy();
             await expect(latestBlockPromise).rejects.toThrow(
-              'Block tracker ended before latest block was available',
+              'Block tracker destroyed',
             );
             expect(blockTracker.isRunning()).toBe(false);
           },

--- a/src/SubscribeBlockTracker.test.ts
+++ b/src/SubscribeBlockTracker.test.ts
@@ -166,6 +166,19 @@ describe('SubscribeBlockTracker', () => {
         });
       });
 
+      it('should reject the returned promise if the block tracker is destroyed in the meantime', async () => {
+        await withSubscribeBlockTracker(async ({ blockTracker }) => {
+          const promiseToGetLatestBlock =
+            blockTracker[methodToGetLatestBlock]();
+          await blockTracker.destroy();
+
+          await expect(promiseToGetLatestBlock).rejects.toThrow(
+            'Block tracker destroyed',
+          );
+          expect(blockTracker.isRunning()).toBe(false);
+        });
+      });
+
       it('should fetch the latest block number', async () => {
         recordCallsToSetTimeout();
 

--- a/src/SubscribeBlockTracker.ts
+++ b/src/SubscribeBlockTracker.ts
@@ -112,6 +112,7 @@ export class SubscribeBlockTracker
       let onLatestBlockUnavailable: InternalListener;
       const onLatestBlockAvailable = (value: string | PromiseLike<string>) => {
         this.#removeInternalListener(onLatestBlockAvailable);
+        this.#removeInternalListener(onLatestBlockUnavailable);
         this.removeListener('error', onLatestBlockUnavailable);
         resolve(value);
       };

--- a/src/SubscribeBlockTracker.ts
+++ b/src/SubscribeBlockTracker.ts
@@ -264,6 +264,7 @@ export class SubscribeBlockTracker
         this._newPotentialLatest(blockNumber);
       } catch (e) {
         this.emit('error', e);
+        this.#rejectPendingLatestBlock(e);
       }
     }
   }
@@ -275,6 +276,7 @@ export class SubscribeBlockTracker
         this._subscriptionId = null;
       } catch (e) {
         this.emit('error', e);
+        this.#rejectPendingLatestBlock(e);
       }
     }
   }


### PR DESCRIPTION
Our block tracker implementation relies on the presence of listeners to establish whether the polling should be continued or stopped.

However, an internal listener is being added in the `getLatestBlock` method, which will count as the other external listeners and will prevent the instance from stopping fetching new blocks. This creates an infinite loop in case the network is unreachable, because of the retry mechanism.  

This PR aims to fix this behavior by keeping track of internal listeners' references in order to exclude them from the listener's count

Fixes https://github.com/MetaMask/eth-block-tracker/issues/163