### PR TITLE
chore: update GitHub Actions to use Ubuntu Latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,7 @@ jobs:
           fi
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - build-lint-test
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -45,7 +45,7 @@ jobs:
           fi
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - build-lint-test
     steps:


### PR DESCRIPTION
Update CI environment from Ubuntu 20.04 to latest ahead of the scheduled 20.04 runner deprecation in April 2025.

See: https://github.com/actions/runner-images/issues/11101