### PR TITLE
docs: format CHANGELOG.md with prettier

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,10 +32,10 @@ jobs:
       - run: yarn test
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate --rc
+        run: yarn auto-changelog validate --rc --prettier
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate
+        run: yarn auto-changelog validate --prettier
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - uses: MetaMask/action-create-release-pr@v1
+      - uses: MetaMask/action-create-release-pr@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,106 +1,146 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
+
 - Fixed hanging `getLatestBlock()` promises when block tracker is stopped before request completion ([#320](https://github.com/MetaMask/eth-block-tracker/pull/320))
   - Pending `getLatestBlock()` requests are now properly rejected with "Block tracker destroyed" error when the tracker is stopped
 
 ## [12.0.0]
+
 ### Changed
+
 - Errors that occur while polling are no longer wrapped ([#310](https://github.com/MetaMask/eth-block-tracker/pull/310))
 
 ### Removed
+
 - **BREAKING:** Remove `SubscribeBlockTracker` ([#309](https://github.com/MetaMask/eth-block-tracker/pull/309))
   - Although we continue to maintain this, we have not used it internally for quite some time. In general we have found a polling-based approval to be reliable than a subscription-based approach. We recommend using `PollingBlockTracker` instead.
 
 ### Fixed
+
 - Fix `PollingBlockTracker.getLatestBlock` so that it throws an error encountered while making the request instead of hanging, regardless of whether the request occurs inside or outside of a polling loop ([#313](https://github.com/MetaMask/eth-block-tracker/pull/313))
 - Fix `PollingBlockTracker.getLatestBlock` so that if invoked while a previous invocation is pending, it will throw if that invocation also throws ([#313](https://github.com/MetaMask/eth-block-tracker/pull/313))
 
 ## [11.0.4]
+
 ### Changed
+
 - Bump `@metamask/utils` from `^9.1.0` to `^11.0.1` ([#297](https://github.com/MetaMask/eth-block-tracker/pull/297))
 
 ## [11.0.3]
+
 ### Fixed
+
 - Avoid risk of infinite retry loops when fetching new blocks ([#284](https://github.com/MetaMask/eth-block-tracker/pull/284))
   - When the provider returns an error and `PollingBlockTracker` or `SubscribeBlockTracker` is destroyed, the promise returned by the `getLatestBlock` method will be rejected.
 
 ## [11.0.2]
+
 ### Fixed
+
 - Bump `@metamask/eth-json-rpc-provider` from `^4.1.1` to `^4.1.5` ([#273](https://github.com/MetaMask/eth-block-tracker/pull/273))
 
 ## [11.0.1]
+
 ### Changed
+
 - Bump `@metamask/eth-json-rpc-provider` from `^4.1.0` to `^4.1.1` ([#261](https://github.com/MetaMask/eth-block-tracker/pull/261))
 - Bump `@metamask/safe-event-emitter` from `^3.0.0` to `^3.1.1` ([#261](https://github.com/MetaMask/eth-block-tracker/pull/261))
 - Bump `@metamask/utils` from `^8.1.0` to `^9.1.0` ([#261](https://github.com/MetaMask/eth-block-tracker/pull/261))
 
 ## [11.0.0]
+
 ### Changed
+
 - **BREAKING**: Adapt to EIP-1193 provider changes by using `request` method of provider instead of `sendAsync` ([#252](https://github.com/MetaMask/eth-block-tracker/pull/252))
   - This change included in `10.1.0` was mistakenly categorised as a non-breaking change.
   - This requires provider object to have the `request` method. You need to upgrade to minimum `4.1.0` of `@metamask/eth-json-rpc-provider` so that the `request` method is available.
 
 ## [10.1.0] [DEPRECATED]
+
 ### Changed
+
 - Adapt to EIP-1193 provider changes ([#252](https://github.com/MetaMask/eth-block-tracker/pull/252))
   - Deprecated `sendAsync` method is replaced with `request` method
 - Bump `@metamask/eth-json-rpc-provider` from `^4.0.0` to `^4.1.0` ([#252](https://github.com/MetaMask/eth-block-tracker/pull/252))
 
 ## [10.0.0]
+
 ### Changed
+
 - BREAKING: Drop support for Node.js v16; add support for Node.js v20, v22 ([#245](https://github.com/MetaMask/eth-block-tracker/pull/245))
 - Update `@metamask/eth-json-rpc-provider` from `^3.0.2` to `^4.0.0` ([#247](https://github.com/MetaMask/eth-block-tracker/pull/247))
 
 ## [9.0.3]
+
 ### Fixed
+
 - Update dependency `@metamask/eth-json-rpc-engine` from `^7.1.1` to `^8.0.2` ([#235](https://github.com/MetaMask/eth-block-tracker/pull/235))
 - Update dependency `@metamask/eth-json-rpc-provider` from `^2.3.1` to `^3.0.2` ([#235](https://github.com/MetaMask/eth-block-tracker/pull/235))
 
 ## [9.0.2]
+
 ### Fixed
+
 - Put back missing empty `params` to `eth_blockNumber` call removed in 9.0.1 ([#198](https://github.com/MetaMask/eth-block-tracker/pull/198))
 
 ## [9.0.1]
+
 ### Fixed
+
 - Concurrency fix: Prevent multiple simultaneous polling loops ([#208](https://github.com/MetaMask/eth-block-tracker/pull/208))
 - Bump `@metamask/eth-json-rpc-provider` from `^2.1.0` to `^2.3.1` ([#198](https://github.com/MetaMask/eth-block-tracker/pull/198)) ([#217](https://github.com/MetaMask/eth-block-tracker/pull/217))
 
 ## [9.0.0]
+
 ### Changed
+
 - Rename package from `eth-block-tracker` to `@metamask/eth-block-tracker` ([#183](https://github.com/MetaMask/eth-block-tracker/pull/183))
 
 ## [8.1.0]
+
 ### Changed
+
 - Typescript: Add `checkForLatestBlock` function to `BlockTracker` interface ([#184](https://github.com/MetaMask/eth-block-tracker/pull/184))
 
 ## [8.0.0]
+
 ### Changed
+
 - Bump @metamask/utils from ^5.0.2 to ^8.1.0 ([#178](https://github.com/MetaMask/eth-block-tracker/pull/178))
 - **BREAKING**: Bump @metamask/eth-json-rpc-provider from ^1.0.0 to ^2.1.0 ([#174](https://github.com/MetaMask/eth-block-tracker/pull/174))
 - **BREAKING**: Increase minimum Node.js version to 16 ([#173](https://github.com/MetaMask/eth-block-tracker/pull/173))
 
 ## [7.2.0]
+
 ### Added
+
 - Typescript: Export `BlockTracker` interface ([#168](https://github.com/MetaMask/eth-block-tracker/pull/168))
 
 ### Changed
+
 - Dependency Updates: ([#165](https://github.com/MetaMask/eth-block-tracker/pull/165))
   - Bump pify from ^3.0.0 to ^5.0.0
   - Bump @metamask/utils from ^5.0.1 to ^5.0.2
 
 ## [7.1.0]
+
 ### Added
+
 - Add `usePastBlocks` to constructor ([#151](https://github.com/MetaMask/eth-block-tracker/pull/151))
   - Optional flag. When set to true, it allows blocks less than the current block number to be cached and returned.
 
 ## [7.0.1]
+
 ### Changed
+
 - Dependency updates:
   - Bump @metamask/utils from 5.0.1 to 5.0.2
     - [#141](https://github.com/MetaMask/eth-block-tracker/pull/141)
@@ -108,24 +148,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump @metamask/safe-event-emitter from 2.0.0 to 3.0.0 ([#143](https://github.com/MetaMask/eth-block-tracker/pull/143))
 
 ## [7.0.0]
+
 ### Changed
+
 - **BREAKING:** The type of the `provider` option for `PollingBlockTracker` and `SubscribeBlockTracker` has changed ([#130](https://github.com/MetaMask/eth-block-tracker/pull/130))
   - The `provider` option must be compatible with the `SafeEventEmitterProvider` type from `@metamask/eth-json-rpc-middleware`.
   - The new provider type should be mostly equivalent, except that it's now expected to have a `send` method. We don't use that `send` method in this package though.
 
 ### Removed
+
 - **BREAKING:** Remove the `Provider` exported type ([#130](https://github.com/MetaMask/eth-block-tracker/pull/130))
   - We now use `@metamask/eth-json-rpc-provider` for this instead, so there was no need to re-export it.
 
 ## [6.1.0]
+
 ### Added
+
 - Add back Provider type that was accidentally removed in 6.0.0 ([#117](https://github.com/MetaMask/eth-block-tracker/pull/117))
 
 ### Fixed
+
 - Align Provider type with `eth-json-rpc-middleware` to prevent typecasting ([#117](https://github.com/MetaMask/eth-block-tracker/pull/117))
 
 ## [6.0.0]
+
 ### Added
+
 - Add logging ([#112](https://github.com/MetaMask/eth-block-tracker/pull/112))
   - You will not be able to see log messages by default, but you can turn them on for this library by setting the `DEBUG` environment variable to `metamask:eth-block-tracker:*` or `metamask:*`.
 - Add `destroy` method to block tracker classes ([#106](https://github.com/MetaMask/eth-block-tracker/pull/106))
@@ -133,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose types that represent options to PollingBlockTracker and SubscribeBlockTracker constructors ([#103](https://github.com/MetaMask/eth-block-tracker/pull/103))
 
 ### Changed
+
 - **BREAKING:** Require Node >= 14 ([#113](https://github.com/MetaMask/eth-block-tracker/pull/113))
 - **BREAKING:** Make BaseBlockTracker abstract ([#103](https://github.com/MetaMask/eth-block-tracker/pull/103))
   - If you are using this class directly, you must only use PollingBlockTracker or SubscribeBlockTracker.
@@ -146,45 +195,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This change was made because OpenEthereum does not support this parameter. While we've done our best to confirm that this will not be a breaking change for other Ethereum implementations, you will want to confirm no breakages for yours.
 
 ### Security
+
 - Add `@lavamoat/allow-scripts` to ensure that install scripts are opt-in for dependencies ([#97](https://github.com/MetaMask/eth-block-tracker/pull/97))
 
 ## [5.0.1] - 2021-03-25
+
 ### Fixed
+
 - Add missing `types` field to `package.json` ([#75](https://github.com/MetaMask/eth-block-tracker/pull/75))
 
 ## [5.0.0] - 2021-03-25
+
 ### Changed
+
 - **(BREAKING)** Refactor exports ([#71](https://github.com/MetaMask/eth-block-tracker/pull/71))
 - **(BREAKING)** Target ES2017, remove ES5 builds ([#71](https://github.com/MetaMask/eth-block-tracker/pull/71))
 - Migrate to TypeScript ([#71](https://github.com/MetaMask/eth-block-tracker/pull/71))
 - Update various dependencies ([#44](https://github.com/MetaMask/eth-block-tracker/pull/44), [#49](https://github.com/MetaMask/eth-block-tracker/pull/49), [#54](https://github.com/MetaMask/eth-block-tracker/pull/54), [#59](https://github.com/MetaMask/eth-block-tracker/pull/59), [#61](https://github.com/MetaMask/eth-block-tracker/pull/61), [#62](https://github.com/MetaMask/eth-block-tracker/pull/62), [#63](https://github.com/MetaMask/eth-block-tracker/pull/63), [#70](https://github.com/MetaMask/eth-block-tracker/pull/70), [#72](https://github.com/MetaMask/eth-block-tracker/pull/72))
 
 ### Removed
+
 - Remove unused production dependencies ([#60](https://github.com/MetaMask/eth-block-tracker/pull/60), [#68](https://github.com/MetaMask/eth-block-tracker/pull/68))
 
 ## [4.4.3] - 2019-08-30
+
 ### Added
+
 - Add SubscribeBlockTracker
 
 ### Changed
+
 - Change events so that they now only return the block number (internal polling is done via `eth_blockNumber`)
 - Add `retryTimeout` and `keepEventLoopActive` to constructor
 - Update block trackers to inherit from `safe-event-emitter` rather than EventEmitter
 
 ### Removed
+
 - Remove `block` event
   - Please use `latest` or `sync`.
 
 ## [4.0.0] - 2018-04-26
+
 ### Added
+
 - Add isRunning method
 - Add `error` event
 
 ### Changed
+
 - Significantly rewrite `eth-block-tracker` (primarily due to optimizing network IO)
 - Rename `awaitCurrentBlock` to `getLatestBlock`
 
 ### Removed
+
 - Remove `stop`/`start` methods from BlockTrackers
   - BlockTrackers now automatically start and stop based on listener count for the `latest` and `sync` events. You can force a stop by calling the `EventEmitter` method `removeAllListeners`.
 - Remove tx body from block
@@ -193,7 +256,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove test/util/testBlockMiddleware
 
 ## [3.0.0] - 2018-04-16
+
 ### Changed
+
 - Update published version so main module now exports unprocessed source
 - Module includes dist:
   - Bundle: `dist/EthBlockTracker.js`
@@ -203,16 +268,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - It no longer provides a callback to event handlers.
 
 ### Fixed
+
 - Fix `awaitCurrentBlock` return value
 
 ## [2.0.0] - 2017-06-14
+
 ### Added
+
 - Expose EventEmitter interface (via `async-eventemitter`)
 - Add `getTrackingBlock`, `getCurrentBlock`, `start`, and `stop`
 - Add events: `block`, `latest`, `sync`
 
 ## [1.0.0] - 2017-02-03
+
 ### Added
+
 - Add RpcBlockTracker
 
 [Unreleased]: https://github.com/MetaMask/eth-block-tracker/compare/v12.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The project follows the same release process as the other libraries in the MetaM
    - Generally any changes that don't affect consumers of the package (e.g. lockfile changes or development environment changes) are omitted. Exceptions may be made for changes that might be of interest despite not having an effect upon the published package (e.g. major test improvements, security improvements, improved documentation, etc.).
    - Try to explain each change in terms that users of the package would understand (e.g. avoid referencing internal variables/concepts).
    - Consolidate related changes into one change entry if it makes it easier to explain.
-   - Run `yarn auto-changelog validate --rc` to check that the changelog is correctly formatted.
+   - Run `yarn auto-changelog validate --rc --prettier` to check that the changelog is correctly formatted.
 
 5. Review and QA the release.
 


### PR DESCRIPTION
This PR does the following:
- bumps `action-create-release-pr` to `v3` (May fix https://github.com/MetaMask/create-release-branch/actions/runs/14524263811)

- formats `CHANGELOG.md` using Prettier and updates the pipelines to use the correct parameters for changelog validation:  both non-RC `yarn auto-changelog validate --prettier`  and RC `yarn auto-changelog validate --rc --prettier` branches.