### PR TITLE
Revert "12.1.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.1.0]
-
 ### Changed
 
-- Bump `@metamask/eth-json-rpc-provider` from `^4.1.5` to `^5.0.0` ([#334](https://github.com/MetaMask/eth-block-tracker/pull/334))
+- Bump `@metamask/eth-json-rpc-provider` from `^4.1.5` to `^5.0.0` ([#297](https://github.com/MetaMask/eth-block-tracker/pull/297))
 
 ## [12.0.1]
 
@@ -293,8 +291,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add RpcBlockTracker
 
-[Unreleased]: https://github.com/MetaMask/eth-block-tracker/compare/v12.1.0...HEAD
-[12.1.0]: https://github.com/MetaMask/eth-block-tracker/compare/v12.0.1...v12.1.0
+[Unreleased]: https://github.com/MetaMask/eth-block-tracker/compare/v12.0.1...HEAD
 [12.0.1]: https://github.com/MetaMask/eth-block-tracker/compare/v12.0.0...v12.0.1
 [12.0.0]: https://github.com/MetaMask/eth-block-tracker/compare/v11.0.4...v12.0.0
 [11.0.4]: https://github.com/MetaMask/eth-block-tracker/compare/v11.0.3...v11.0.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-block-tracker",
-  "version": "12.1.0",
+  "version": "12.0.1",
   "description": "A block tracker for the Ethereum blockchain. Keeps track of the latest block",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts MetaMask/eth-block-tracker#335

This repository doesn't have automatic publishing setup yet, so the release was not published. I will re-attempt after the publishing workflows have been added.