### PR TITLE
docs: Add migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # @metamask/eth-block-tracker
 
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over.</p></td></tr></table>
+<table>
+  <tr>
+    <td>
+      <p align="center"><b>⚠️ PLEASE READ ⚠️</b></p>
+      <p align="center">
+        This package has been migrated to our
+        <a href="https://github.com/MetaMask/core"><code>core</code></a>
+        monorepo, and this repository has been archived. Please note that all
+        future development and feature releases will take place in the
+        <a href="https://github.com/MetaMask/core"><code>core</code></a>
+        repository.
+      </p>
+    </td>
+  </tr>
+</table>
 
 This module walks the Ethereum blockchain, keeping track of the latest block. It uses a web3 provider as a data source and will continuously poll for the next block.
 


### PR DESCRIPTION
Updated README to reflect migration to core monorepo and archiving of the repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to indicate the repo is archived and future development occurs in the core monorepo.
> 
> - **Documentation**:
>   - Update notice in `README.md` to reflect completed migration, repository archival, and redirect future development to `core` monorepo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7017531aa7d25b3a9b64d419e0625725b7640679. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->